### PR TITLE
Update default.typst for upcoming typst 0.12

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -28,6 +28,10 @@ $else$
 $template.typst()$
 $endif$
 
+#set page(
+  columns: $if(columns)$$columns$$else$1$endif$,
+)
+
 $if(smart)$
 $else$
 #set smartquote(enabled: false)
@@ -89,7 +93,6 @@ $endif$
 $if(section-numbering)$
   sectionnumbering: "$section-numbering$",
 $endif$
-  cols: $if(columns)$$columns$$else$1$endif$,
   doc,
 )
 


### PR DESCRIPTION
two column layout instructions have changed in typst 0.12; see  https://github.com/typst/typst/issues/5215 for details.